### PR TITLE
allow removal of localTime field

### DIFF
--- a/index.js
+++ b/index.js
@@ -247,8 +247,9 @@ export default class TidepoolDataTools {
 
   static tidepoolProcessor(processorConfig = {}) {
     return es.mapSync((data) => {
-      // Synthesize the 'localTime' field
-      this.addLocalTime(data);
+      if (!processorConfig.excludeLocalTime) {
+        this.addLocalTime(data);
+      }
       // Stringify objects configured with { "stringify": true }
       this.stringifyFields(data);
       // Convert BGL data to mg/dL if configured to do so

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/data-tools",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "description": "Export data from the Tidepool API to various file formats",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Previously the code would add a number of minutes equal to the localTimezone. This is not correct, as JS stores dates in UTC. Adding the offset therefore did not adjust the timezone that's displayed, but rather changed the actual time value.

Since the offset is supplied, clients wishing to calculate the local time can do so on their own.

BACK-4205